### PR TITLE
Add ROS Support page.

### DIFF
--- a/content/support.md
+++ b/content/support.md
@@ -1,0 +1,34 @@
+---
+title: Support
+layout: /general.*
+---
+
+# Support
+
+There are several mechanisms in place to provide support to the ROS community, each with its own purpose: the wiki, ROS Answers, issue trackers, and the ros-users@ mailing list.
+It is important to pick the right resource to reduce response time, avoid message duplication, and promote the discussion of new ideas.
+
+## Wiki
+
+When something goes wrong, the [ROS wiki](https://wiki.ros.org) is your first stop.
+In addition to the official documentation for ROS packages, the wiki contains two key resources you should consult: the Troubleshooting guide and the FAQ.
+Solutions to many common problems are covered in these two pages.
+
+## ROS Answers
+
+If the wiki doesn't address your problem, [ROS Answers](https://answers.ros.org) is next.
+Take heart: it is very likely that someone else has faced the same problem before, and that it's covered among the more than 10,000 questions at ROS Answers.
+Start by searching for questions similar to yours; if your question isn't already asked, post a new one.
+Be sure to check the guidelines on how to prepare your question before posting.
+
+## Issue trackers
+
+When you've identified a bug (e.g., as a result of a discussion at ROS Answers), or when you want to request a new feature, head to the issue trackers.
+When reporting a bug, be sure to provide a detailed description of the problem, the environment in which it occurs, any detail that may help developers to reproduce the issue, and if possible, a debug backtrace.
+
+## ROS Discourse Forums
+
+To stay up-to-date on the latest developments within the ROS community, you'll want to join the [ROS Discourse](https://discourse.ros.org) forums.
+These forums, are the place for announcements, news, and discussions of general interest.
+The ROS Discourse is not the right place to ask troubleshooting questions or report bugs; please use the other support resources listed above instead.
+


### PR DESCRIPTION
This is based on the page that used to be at https://www.ros.org/support

I'm sure that there's more we can do but given how often this page is
cited it would be nice to have something up there.