### PR TITLE
community: correct ROS-Industrial name

### DIFF
--- a/content/blog/community/index.md
+++ b/content/blog/community/index.md
@@ -109,6 +109,6 @@ The [Nav 2](https://navigation.ros.org/) project is the spiritual successor of t
   <img  width=400 src="/imgs/rosindustrial.png" />
 </div>
 
-## ROS Industrial
+## ROS-Industrial
 
-[ROS Industrial](https://rosindustrial.org/) is an open-source project that extends the advanced capabilities of ROS software to industrial relevant hardware and applications.
+[ROS-Industrial](https://rosindustrial.org/) is an open-source project that extends the advanced capabilities of ROS software to industrial relevant hardware and applications.


### PR DESCRIPTION
As per subject.

Changes it to read:

![image](https://user-images.githubusercontent.com/4550046/144468619-03b81459-aba7-4cda-90a4-370a1f4aa556.png)

