### PR TITLE
Add a ROS 1 wiki link to the landing page

### DIFF
--- a/content/css/mobile-styles.scss
+++ b/content/css/mobile-styles.scss
@@ -307,6 +307,28 @@
       width: auto;
       padding-top: 20px;
     }
+
+    .support-wiki-ros1 {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      height: auto;
+      margin-top: 10px;
+    }
+    .img-4 {
+      height: 50px;
+      padding-left: 15px;
+    }
+    .img-caption-4 {
+      padding-top: 20px;
+      font-size: 18px;
+      width: auto;
+    }
+    .blurb-4 {
+      padding-top: 20px;
+      width: auto;
+    }
   }
   .blog-newsletter {
     display: block;

--- a/content/css/stylesheet.scss
+++ b/content/css/stylesheet.scss
@@ -917,6 +917,9 @@ button.owl-next {
   justify-content: center;
   background-color: $white;
   p {
+    padding-top: unset;
+    width: unset;
+    height: unset;
     text-align: center;
     font-size: 18px;
   }

--- a/content/css/stylesheet.scss
+++ b/content/css/stylesheet.scss
@@ -917,7 +917,7 @@ button.owl-next {
   justify-content: center;
   background-color: $white;
   p {
-    text-align: justify;
+    text-align: center;
     font-size: 18px;
   }
   strong {

--- a/content/css/stylesheet.scss
+++ b/content/css/stylesheet.scss
@@ -912,7 +912,7 @@ button.owl-next {
 
 .support-grid {
   display: grid;
-  grid-template-columns: 175px 100px 175px 100px 175px;
+  grid-template-columns: 175px 100px 175px 100px 175px 100px 175px;
   grid-template-rows: 175px 50px 150px;
   justify-content: center;
   background-color: $white;

--- a/content/css/stylesheet.scss
+++ b/content/css/stylesheet.scss
@@ -979,6 +979,21 @@ button.owl-next {
     grid-column-start: 5;
     grid-row-start: 3;
   }
+  .img-4 {
+    justify-self: center;
+    height: 75px;
+    grid-column-start: 7;
+    grid-row-start: 1;
+  }
+  .img-caption-4 {
+    font-size: 22px;
+    grid-column-start: 7;
+    grid-row-start: 2;
+  }
+  .blurb-4 {
+    grid-column-start: 7;
+    grid-row-start: 3;
+  }
 }
 
 .blog-newsletter {

--- a/content/index.html
+++ b/content/index.html
@@ -125,7 +125,7 @@ title: Home
 	    ROS Answers
 	  </a>
 	</strong>
-	<p class="blurb-2">Ask questions. Get answers.</p>
+	<p class="blurb-2">Ask questions.<br/>Get answers.<br/>All ROS versions</p>
 
 
 	<img src="imgs/forums-icon.svg" class="img-3" />
@@ -151,7 +151,7 @@ title: Home
         <div class="support-ros-answers">
           <a href="http://answers.ros.org/"><img src="imgs/ros-answers-icon.svg" class="img-2" /></a>
           <a href="http://answers.ros.org/"><strong class="img-caption-2">ROS Answers</strong></a>
-          <p class="blurb-2">Ask questions. Get answers.</p>
+          <p class="blurb-2">Ask questions.<br/>Get answers.<br/>All ROS versions</p>
         </div>
         <div class="support-forums">
           <a href="http://discourse.ros.org/"><img src="imgs/forums-icon.svg" class="img-3" /></a>

--- a/content/index.html
+++ b/content/index.html
@@ -117,7 +117,7 @@ title: Home
 	<strong class="img-caption-1">
 	  <a href="http://docs.ros.org/">Documentation</a>
 	</strong>
-	<p class="blurb-1">Find documentation and tutorials</p>
+	<p class="blurb-1">Documentation and tutorials for ROS 2</p>
 
 	<img src="imgs/ros-answers-icon.svg" class="img-2" />
 	<strong class="img-caption-2">
@@ -146,7 +146,7 @@ title: Home
         <div class="support-wiki">
           <a href="http://docs.ros.org/"><img src="imgs/wiki-icon.svg" class="img-1" /></a>
           <strong class="img-caption-1"><a href="http://docs.ros.org/">Documentation</a></strong>
-          <p class="blurb-1">Find documentation and tutorials</p>
+          <p class="blurb-1">Documentation and tutorials for ROS 2</p>
         </div>
         <div class="support-ros-answers">
           <a href="http://answers.ros.org/"><img src="imgs/ros-answers-icon.svg" class="img-2" /></a>

--- a/content/index.html
+++ b/content/index.html
@@ -133,6 +133,12 @@ title: Home
 	  <a href="http://discourse.ros.org">Forums</a>
 	</strong>
 	<p class="blurb-3">Hear the latest discussions</p>
+
+  <img src="imgs/wiki-icon.svg" class="img-4" />
+  <strong class="img-caption-4">
+    <a href="https://wiki.ros.org">ROS 1 Wiki</a>
+  </strong>
+  <p class="blurb-4">Legacy documentation and tutorials for ROS 1</p>
     </div>
 
     <div class="support-carousel-mob">
@@ -151,6 +157,11 @@ title: Home
           <a href="http://discourse.ros.org/"><img src="imgs/forums-icon.svg" class="img-3" /></a>
           <a href="http://discourse.ros.org/"><strong class="img-caption-3">Forums</strong></a>
           <p class="blurb-3">Hear the latest discussions</p>
+        </div>
+        <div class="support-wiki-ros1">
+          <a href="https://wiki.ros.org/"><img src="imgs/wiki-icon.svg" class="img-4" /></a>
+          <a href="https://wiki.ros.org/"><strong class="img-caption-4">ROS 1 Wiki</strong></a>
+          <p class="blurb-4">Legacy documentation and tutorials for ROS 1</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
As per subject.

I believe this respects the focus on ROS 2, while still making the ROS 1 wiki easy to find:

![image](https://user-images.githubusercontent.com/4550046/144478425-aab17d88-9b95-44bc-84e7-a916669e5f16.png)

To get things to align correctly and render with the correct sizes, I've had to `unset` some of the properties, but that *should* only affect `p`s inside `.support-grid`.

I've updated the base stylesheet and the mobile one. As the other stylesheets did not seem like they had been edited, I've not changed those either.

The carousal didn't seem to work for me, even without my changes, so I've replicated what was there to add the 4th column, but have not checked it.

Tested on Firefox 94 and Chrome (latest version). Desktop only.
