### PR TITLE
Updated favicon to correct href

### DIFF
--- a/layouts/_head.html.erb
+++ b/layouts/_head.html.erb
@@ -38,7 +38,7 @@
   />
   <link
     rel="shortcut icon"
-    href="https://www.ros.org/wp-content/uploads/2013/10/rosorg-favicon.png"
+    href="/favicon.ico"
     type="image/x-icon"
   />
   <script src="/javascript/default.js"></script>


### PR DESCRIPTION
Noticed the favicon was pointing at a file that does not exist. 
Updated it to point to the file inside the public content folder /favicon.ico 

