### PR TITLE
www.ros.org is hosted on ros2.osuosl.org now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Now, you need to tell the upload script where to look for the SSH key file for t
 ``` 
 Host ros1.osuosl.org osuoslros
      User ros
-     HostName ros1.osuosl.org
+     HostName ros2.osuosl.org
      ForwardAgent yes
      ServerAliveInterval 30
      ServerAliveCountMax 4


### PR DESCRIPTION
Update the documented host for www.ros.org deployment.