### PR TITLE
Remove Discord Server information and replace with zulip

### DIFF
--- a/content/blog/getting-started/index.md
+++ b/content/blog/getting-started/index.md
@@ -112,13 +112,6 @@ interest.  The ROS Discourse is **not the right place to ask troubleshooting
 questions or report bugs**; please use the other support resources listed above
 instead.
 
-### [Open Robotics Discord Server  <i style="font-size: 1rem;" class="fas fa-users"></i>](/blog/discord/)
-
-Open Robotics hosts a [community Discord server](/blog/discord/) where ROS,
-Gazebo, and Open-RMF users can meet with each other, chat, and coordinate on
-open-source development. If you are looking to connect with ROS users this a
-great place to start.
-
 ### [ROS Index <i style="font-size: 1rem;" class="fas fa-sitemap"></i>](https://index.ros.org)
 
 When you want to find out information about a specific package the

--- a/content/blog/getting-started/index.md
+++ b/content/blog/getting-started/index.md
@@ -112,6 +112,13 @@ interest.  The ROS Discourse is **not the right place to ask troubleshooting
 questions or report bugs**; please use the other support resources listed above
 instead.
 
+### [Open Robotics Zulip Server  <i style="font-size: 1rem;" class="fas fa-users"></i>](https://openrobotics.zulipchat.com/)
+
+Open Robotics hosts a [community Zulip server](https://openrobotics.zulipchat.com/) where ROS,
+Gazebo, and Open-RMF users can meet with each other, chat, and coordinate on
+open-source development. If you are looking to connect with ROS users this a
+great place to start.
+
 ### [ROS Index <i style="font-size: 1rem;" class="fas fa-sitemap"></i>](https://index.ros.org)
 
 When you want to find out information about a specific package the

--- a/content/blog/noetic-eol/index.md
+++ b/content/blog/noetic-eol/index.md
@@ -172,7 +172,7 @@ If you run into migration problem that you just can't solve feel free to swing b
 
 
 * [Discourse](https://discourse.ros.org/) -- our ROS discussion forum.
-* [ROS Discord](https://discord.com/servers/open-robotics-1077825543698927656) -- our live discussion server.
+* [ROS Zulip](https://openrobotics.zulipchat.com/) -- our live developer discussion server.
 * [Robotics Stack Exchange](https://robotics.stackexchange.com/) -- our preferred Q&A forum.
 * [Official ROS 2 Documentation](https://docs.ros.org/) -- our official ROS documentation.
 * [ROS Package API reference](https://docs.ros.org/en/rolling/p/) -- API documentation for ROS package.

--- a/content/blog/noetic-eol/index.md
+++ b/content/blog/noetic-eol/index.md
@@ -172,7 +172,7 @@ If you run into migration problem that you just can't solve feel free to swing b
 
 
 * [Discourse](https://discourse.ros.org/) -- our ROS discussion forum.
-* [ROS Zulip](https://openrobotics.zulipchat.com/) -- our live developer discussion server.
+* [ROS Zulip](https://openrobotics.zulipchat.com/) -- our live community and developer discussion server.
 * [Robotics Stack Exchange](https://robotics.stackexchange.com/) -- our preferred Q&A forum.
 * [Official ROS 2 Documentation](https://docs.ros.org/) -- our official ROS documentation.
 * [ROS Package API reference](https://docs.ros.org/en/rolling/p/) -- API documentation for ROS package.

--- a/layouts/_footer.html.erb
+++ b/layouts/_footer.html.erb
@@ -29,7 +29,7 @@
         <li><a href="http://index.ros.org">Packages</a></li>
         <li><a href="http://roscon.ros.org">ROSCon</a></li>
 	<li><a href="http://docs.ros.org">documentation</a></li>
-	<li><a href="/blog/discord">discord</a></li>
+	<li><a href="/blog/discord">https://openrobotics.zulipchat.com/</a></li>
       </ul>
     </div>
     <div class="legal">

--- a/layouts/_footer.html.erb
+++ b/layouts/_footer.html.erb
@@ -28,8 +28,8 @@
         <li><a href="http://discourse.ros.org">Forum</a></li>
         <li><a href="http://index.ros.org">Packages</a></li>
         <li><a href="http://roscon.ros.org">ROSCon</a></li>
-	<li><a href="http://docs.ros.org">documentation</a></li>
-	<li><a href="/blog/discord">https://openrobotics.zulipchat.com/</a></li>
+	<li><a href="http://docs.ros.org">Documentation</a></li>
+	<li><a href="https://openrobotics.zulipchat.com/">Zulip</a></li>
       </ul>
     </div>
     <div class="legal">


### PR DESCRIPTION
Removing the discord notion on the ros.org website and replace with zulip where necessary:

* Changed Discord it to Zulip in the footer (used the direct link since there is no blog available)
* Changed the link in the EOL blog 
* I removed the full notion of discord out of the getting-started page, since as I understood it from the [discourse post](https://discourse.openrobotics.org/t/open-robotics-launches-zulip-chat-server/50673), we don't really recommend discord to starters anymore right?
* The [discord blogpost](https://www.ros.org/blog/discord/) is kept as is... but would it maybe need a warning on top? 